### PR TITLE
Sjh player controller

### DIFF
--- a/Assets/Resources/Skills/Fireball.asset
+++ b/Assets/Resources/Skills/Fireball.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   <SkillName>k__BackingField: "\uD30C\uC774\uC5B4\uBCFC"
   <Description>k__BackingField: "\uBD88"
   <Damage>k__BackingField: 10
-  <Cooldown>k__BackingField: 0.5
+  <Cooldown>k__BackingField: 5
   <IsCooldown>k__BackingField: 1
   <Range>k__BackingField: 2
   <SkillPrefab>k__BackingField: {fileID: 99062240329242543, guid: 64a35954a8738c74caea13e6d040b68f, type: 3}

--- a/Assets/Resources/Skills/Fireball.asset
+++ b/Assets/Resources/Skills/Fireball.asset
@@ -16,6 +16,6 @@ MonoBehaviour:
   <Description>k__BackingField: "\uBD88"
   <Damage>k__BackingField: 10
   <Cooldown>k__BackingField: 0.5
-  <IsCooldown>k__BackingField: 0
+  <IsCooldown>k__BackingField: 1
   <Range>k__BackingField: 2
   <SkillPrefab>k__BackingField: {fileID: 99062240329242543, guid: 64a35954a8738c74caea13e6d040b68f, type: 3}

--- a/Assets/SJH/SJH_Scene.unity
+++ b/Assets/SJH/SJH_Scene.unity
@@ -1885,7 +1885,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1938801741
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/SJH/SJH_Scene.unity
+++ b/Assets/SJH/SJH_Scene.unity
@@ -122,136 +122,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &29207771
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 29207773}
-  - component: {fileID: 29207772}
-  - component: {fileID: 29207774}
-  m_Layer: 0
-  m_Name: Sandbag
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &29207772
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 29207771}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &29207773
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 29207771}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5.73, y: 0.05, z: 0}
-  m_LocalScale: {x: 1.28, y: 3.6493998, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &29207774
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 29207771}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
 --- !u!1001 &241825219
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2015,7 +1885,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &1938801741
 Transform:
   m_ObjectHideFlags: 0
@@ -3052,9 +2922,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   PlayerView: {fileID: 0}
+  PlayerAI:
+    TargetMonster: {fileID: 0}
+    TargetSkill: {fileID: 0}
+  _mode: 0
   CurrentState: 1
-  SkillKeys: 4301000044010000
-  AttackDistance: 8
+  SearchDistance: 8
   DirectionCount: 8
   SightAngle: 45
   MonsterLayer:
@@ -3066,7 +2939,6 @@ SceneRoots:
   m_Roots:
   - {fileID: 940699494}
   - {fileID: 8403607940018651966}
-  - {fileID: 29207773}
   - {fileID: 1427771335}
   - {fileID: 1718986718}
   - {fileID: 8326027889338650383}

--- a/Assets/SJH/SJH_Scene.unity
+++ b/Assets/SJH/SJH_Scene.unity
@@ -180,7 +180,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7038559896971601749, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8804913719555977660, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_SortingOrder
@@ -550,7 +550,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7038559896971601749, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8804913719555977660, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_SortingOrder
@@ -769,7 +769,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7038559896971601749, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8804913719555977660, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_SortingOrder
@@ -869,7 +869,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7038559896971601749, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8804913719555977660, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_SortingOrder
@@ -1179,7 +1179,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7038559896971601749, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8804913719555977660, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_SortingOrder
@@ -1543,7 +1543,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7038559896971601749, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8804913719555977660, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_SortingOrder
@@ -1658,7 +1658,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7038559896971601749, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8804913719555977660, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_SortingOrder
@@ -2033,7 +2033,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7038559896971601749, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8804913719555977660, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_SortingOrder
@@ -2223,7 +2223,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7038559896971601749, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8804913719555977660, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_SortingOrder
@@ -2428,7 +2428,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7038559896971601749, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8804913719555977660, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_SortingOrder
@@ -2497,7 +2497,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7038559896971601749, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8804913719555977660, guid: ace26ca5c45828241bbc7737cea7d36c, type: 3}
       propertyPath: m_SortingOrder

--- a/Assets/SJH/SJH_Scripts/PlayerAI.cs
+++ b/Assets/SJH/SJH_Scripts/PlayerAI.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -110,9 +110,10 @@ public class PlayerAI
 			}
 		}
 		if (TargetSkill == null) _controller.CurrentState = AIState.Search;
-		// 사용 가능한 스킬을 TargetSkill 에 등록 후 Chase로 변경
-		_controller.CurrentState = _controller.Mode == ControlMode.Auto ? AIState.Chase : AIState.Attack;
-	}
+        // 사용 가능한 스킬을 TargetSkill 에 등록 후 Chase로 변경
+        _controller.CurrentState = AIState.Chase;
+
+    }
 
 	void ChaseAction()
 	{
@@ -144,12 +145,8 @@ public class PlayerAI
 		if (distance > TargetSkill.Range)
 		{
 			Debug.Log("Attack Action : 공격 스킬 사거리 멀음 추격 전환");
-			// 자동모드일때만 추격으로 전환
-			if (_controller.Mode == ControlMode.Auto)
-				_controller.CurrentState = AIState.Chase;
-			else
-				TargetMonster = null;
-			return;
+            _controller.CurrentState = AIState.Chase;
+            return;
 		}
 
 		// 스킬 사용

--- a/Assets/SJH/SJH_Scripts/PlayerAI.cs
+++ b/Assets/SJH/SJH_Scripts/PlayerAI.cs
@@ -53,33 +53,39 @@ public class PlayerAI
 	{
 		Debug.Log("SkillLoad Action");
 
-		// 모든 스킬이 쿨타임이면 Search로 이동
 		TargetSkill = null;
-		float maxCooldown = float.MinValue;
+		//float maxCooldown = float.MinValue;
 
-		foreach (var skill in GameManager.Instance.SkillDic.Values)
+		List<SkillData> ranSkills = new();
+        // TODO : 게임매니저의 딕셔너리가 아닌 플레이어가 등록한 스킬리스트
+        // 기본공격은 이 리스트에 없어야함
+        // -> 모든 스킬이 쿨타임일 때 사용할 예정 
+        foreach (var skill in GameManager.Instance.SkillDic.Values)
 		{
 			// 스킬 쿨타임이 아니고 쿨타임이 가장 긴 스킬 우선
-			if (!skill.IsCooldown && skill.Cooldown > maxCooldown)
-			{
-				maxCooldown = skill.Cooldown;
-				TargetSkill = skill;
-				Debug.Log($"{TargetSkill.SkillName} 장전");
-			}
-		}
-		// 사용 가능한 스킬을 TargetSkill 에 등록 후 Chase로 변경
-		if (TargetSkill != null)
-        {
-			_controller.CurrentState = AIState.Chase;
+			//if (!skill.IsCooldown && skill.Cooldown > maxCooldown)
+			//{
+			//	maxCooldown = skill.Cooldown;
+			//	TargetSkill = skill;
+			//	Debug.Log($"{TargetSkill.SkillName} 장전");
+			//}
 
-        }
-		else
+            // 쿨타임이 아닌 스킬 등록
+			if (!skill.IsCooldown) ranSkills.Add(skill);
+		}
+        // 쿨타임이 아닌 스킬들 중 랜덤 사용
+        if (ranSkills.Count > 0)
         {
-            // 스킬이 쿨타임일 때는 TargetMonster도 초기화해야지 SearchRoutine에서 안걸림
-			_controller.CurrentState = AIState.Search;
-            MonsterSkillCheck();
+            TargetSkill = ranSkills[Random.Range(0, ranSkills.Count)];
+            Debug.Log($"{TargetSkill.SkillName} 스킬장전");
         }
-	}
+        // TODO : else 기본공격을 TargetSkill로 등록
+
+        // 사용 가능한 스킬을 TargetSkill 에 등록 후 Chase로 변경
+        if (TargetSkill != null) _controller.CurrentState = AIState.Chase;
+        // 스킬이 쿨타임일 때는 TargetMonster도 초기화해야 SearchRoutine에서 안걸림
+        else MonsterSkillCheck();
+    }
 
 	void ChaseAction()
 	{
@@ -247,5 +253,4 @@ public class PlayerAI
 			_searchRoutine = null;
 		}
 	}
-
 }

--- a/Assets/SJH/SJH_Scripts/PlayerAI.cs
+++ b/Assets/SJH/SJH_Scripts/PlayerAI.cs
@@ -104,7 +104,7 @@ public class PlayerAI
 		}
 
 		// 공격할 수 없으면 공격거리까지 이동 후 Skill로
-		_view.Move(dir.normalized, _model.Data.MoveSpeed);
+		_view.Move(dir.normalized, _model.Data.Speed);
 		if (_searchRoutine == null) _searchRoutine = _controller.StartCoroutine(SearchRoutine());
 	}
 

--- a/Assets/SJH/SJH_Scripts/PlayerController.cs
+++ b/Assets/SJH/SJH_Scripts/PlayerController.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using UnityEngine;
 
 #region enum ControlMode
@@ -106,12 +106,8 @@ public class PlayerController : MonoBehaviour
 		if (Mode == ControlMode.Auto) PlayerAI.Action();
 
 		// 수동 컨트롤
-		else if (Mode == ControlMode.Manual)
-		{
-			InputHandler();
-			PlayerAI.Action();
-		}
-	}
+		else if (Mode == ControlMode.Manual) InputHandler();
+    }
 
 	public void InputHandler()
 	{
@@ -128,6 +124,7 @@ public class PlayerController : MonoBehaviour
 
 	void SkillInput()
 	{
+        // TODO : 키세팅
 		if (Input.GetKeyDown(KeyCode.Mouse0))
 		{
 			var skill = GameManager.Instance.GetSkill("Fireball");

--- a/Assets/SJH/SJH_Scripts/PlayerController.cs
+++ b/Assets/SJH/SJH_Scripts/PlayerController.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 public enum ControlMode
 {
 	/// <summary>
-	/// 수동 조작 : 이동은 플레이어, 공격은 AI에서 처리
+	/// 수동 조작 : 이동, 공격 전부 플레이어가 조작
 	/// </summary>
 	Manual,
 	/// <summary>
@@ -20,32 +20,28 @@ public enum ControlMode
 
 #region enum AIState
 /// <summary>
-/// 자동 모드에서의 플레이어 AI 상태.
+/// 자동 모드에서의 플레이어 AI 상태
 /// </summary>
 public enum AIState
 {
+    Idle,
 	/// <summary>
-	/// 아무 행동도 하지 않는 대기 상태.
-	/// </summary>
-	Idle,
-
-	/// <summary>
-	/// 적을 탐색 중인 상태.
+	/// 적을 탐색 중인 상태
 	/// </summary>
 	Search,
 
 	/// <summary>
-	/// 탐지한 적을 향해 추격 중인 상태.
+	/// 탐지한 적을 향해 추격 중인 상태
 	/// </summary>
 	Chase,
 
 	/// <summary>
-	/// 스킬 사용 준비 중인 상태. (예: 캐스팅 시간 등)
+	/// 사용할 스킬을 선택하는 상태
 	/// </summary>
 	SkillLoad,
 
 	/// <summary>
-	/// 적을 공격 중인 상태.
+	/// 적을 공격하는 상태
 	/// </summary>
 	Attack
 }

--- a/Assets/SJH/SJH_Scripts/PlayerController.cs
+++ b/Assets/SJH/SJH_Scripts/PlayerController.cs
@@ -115,7 +115,7 @@ public class PlayerController : MonoBehaviour
 	void MoveInput()
 	{
 		MoveDir = new Vector2(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical")).normalized;
-		PlayerView.Move(MoveDir, _playerModel.Data.MoveSpeed);
+		PlayerView.Move(MoveDir, _playerModel.Data.Speed);
 	}
 
 	void SkillInput()

--- a/Assets/SJH/SJH_Scripts/PlayerData.cs
+++ b/Assets/SJH/SJH_Scripts/PlayerData.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System;
 
 
 /// <summary>
@@ -10,40 +11,105 @@ using UnityEngine;
 public class PlayerData
 {
 	// baseStat * Mathf.Pow(rate, level - 1);
-	public const float AttackRate = 1.12f;
+	public const double AttackRate = 1.12f;
+    public const int AttackBase = 10;
 	public const float HpRate = 1.1f;
+	public const float DefenseRate = 1.08f;
 	public const float LevelupCostRate = 1.15f;
 
 	// TODO : 방어력, 이동속도는 각각의 계산식을 통해 변환될 예정
 
-	// 캐릭터 스텟 레벨 1 ~ 300
-	public int Level { get; private set; }
+    /// <summary>
+    /// 플레이어 전투력
+    /// </summary>
+    public long PowerLevel { get; private set; }
 
-	// 공격력 10 ~ 5,202,220,766,384,660
-	public long Attack { get; set; }
-	// 방어력 (받피감) 12 ~ 1200
-	public int Defense { get; set; }
-	// 최대 체력 100 ~ 237,910,090,562,588
-	public long MaxHp { get; set; }
-	// 체력
-	public long Hp { get; set; }
-	// 이동 속도
-	public int MoveSpeed { get; set; } // 100 ~ 200 / 51레벨까지
-	// 체력 재생 (3%)
-	public float HpRegen { get; set; }
+    /// <summary>
+    /// 공격력 10 ~ 5,202,220,766,384,660
+    /// </summary>
+    public long Attack { get; private set; }
+    /// <summary>
+    /// 공격력 레벨 1 ~ 300
+    /// </summary>
+    public int AttackLevel { get; private set; }
 
-	// 가하는 피해 증가 (특수 스탯)
-	public float IncreaseDamage { get; set; }
+    /// <summary>
+    /// 방어력 (받피감) 12 ~ 1200
+    /// </summary>
+    public int Defense { get; private set; }
+    /// <summary>
+    /// 방어력 레벨 1 ~ 300
+    /// </summary>
+    public int DefenseLevel { get; private set; }
 
-	public PlayerData(int level = 1, long attack = 10, int defense = 12, long maxhp = 100, long hp = 100, int moveSpeed = 100, float hpRegen = 0.03f, float increaseDamage = 0)
+    /// <summary>
+    /// 최대 체력 100 ~ 237,910,090,562,588
+    /// </summary>
+    public long MaxHp { get; private set; }
+    /// <summary>
+    /// 체력 레벨 1 ~ 300
+    /// </summary>
+    public long HpLevel { get; private set; }
+
+	/// <summary>
+    /// 현재 체력
+    /// </summary>
+	public long Hp { get; private set; }
+
+    /// <summary>
+    /// 이동 속도 100 ~ 200, 이동속도 / 50 = 유니티 이속
+    /// </summary>
+    public int Speed { get; private set; }
+    /// <summary>
+    /// 이동 속도 레벨 51레벨까지
+    /// </summary>
+    public int SpeedLevel { get; private set; }
+
+    /// <summary>
+    /// 가하는 피해 증가 (특수 스탯) 기본 5%, 0.2% 씩 증가
+    /// </summary>
+    public float IncreaseDamage { get; private set; }
+    /// <summary>
+    /// 가하는 피해 증가 레벨
+    /// </summary>
+    public int IncreaseDamageLevel { get; private set; }
+
+	public PlayerData(int attackLevel = 115, int defenseLevel = 1, int hpLevel = 1, int speedLevel = 1, int increaseDamageLevel = 0)
 	{
-		Level = level;
-		Attack = attack;
-		Defense = defense;
-		MaxHp = maxhp;
-		Hp = hp;
-		MoveSpeed = moveSpeed / 50;
-		HpRegen = hpRegen;
-		IncreaseDamage = increaseDamage;
-	}
+		AttackLevel = attackLevel;
+        DefenseLevel = defenseLevel;
+        HpLevel = hpLevel;
+        Speed = speedLevel; // / 50;
+		IncreaseDamageLevel = increaseDamageLevel;
+
+        SetAttack(AttackLevel);
+        TestAttack();
+
+    }
+
+    // TODO : 유저가 스탯을 올리는 방식
+    public void SetAttack(int attackLevel)
+    {
+        double value = AttackBase * Math.Pow(AttackRate, attackLevel - 1);
+        long result = (long)Math.Round(value);
+        Debug.Log($"{AttackLevel} 레벨 공격력 : {result}");
+
+        //baseStat * Mathf.Pow(rate, level - 1);
+    }
+
+    void TestAttack()
+    {
+        for (int i = 1; i <= 300; i++)
+        {
+            double value = Math.Pow(AttackRate, i - 1) * AttackBase;
+            long attack = (long)Math.Round(value);
+            Debug.Log($"{i} 레벨 공격력 : {attack}");
+        }
+    }
+
+    public void DecreaseHp(long damage)
+    {
+        Hp -= damage;
+        if (Hp <= 0) Hp = 0;
+    }
 }

--- a/Assets/SJH/SJH_Scripts/PlayerModel.cs
+++ b/Assets/SJH/SJH_Scripts/PlayerModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -27,6 +27,10 @@ public class PlayerModel
 
 	public void ApplyDamage(long damage)
 	{
-		Data.Hp -= damage;
+		Data.DecreaseHp(damage);
+        if (Data.Hp <= 0)
+        {
+            Debug.Log("플레이어 사망");
+        }
 	}
 }

--- a/Assets/SJH/SJH_Scripts/Projectile.cs
+++ b/Assets/SJH/SJH_Scripts/Projectile.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -20,6 +20,7 @@ public class Projectile : MonoBehaviour
 				if (mon != null)
 				{
 					mon.TakeDamage(TotalDamage);
+                    Destroy(gameObject);
 				}
 				break;
 		}

--- a/Assets/SJH/ScriptableObjects/SkillData.cs
+++ b/Assets/SJH/ScriptableObjects/SkillData.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using Unity.VisualScripting;
 using UnityEngine;
@@ -10,7 +10,7 @@ public abstract class SkillData : ScriptableObject
 	[field : SerializeField] public string Description { get; private set; }
 	[field : SerializeField] public int Damage { get; private set; }
 	[field : SerializeField] public float Cooldown { get; private set; }
-	[field: SerializeField] public bool IsCooldown { get; private set; } = false;
+	[field: SerializeField] public bool IsCooldown { get; set; } = false;
 	[field : SerializeField] public float Range { get; private set; }
 	[field : SerializeField] public GameObject SkillPrefab { get; private set; }
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -22,6 +22,10 @@ public class GameManager : Singleton<GameManager>
 		// 스킬을 사용한다는건 오브젝트풀 사용
 		// 오브젝트풀에서 사용할 오브젝트를 가져오고 플레이어의 스탯 * 스킬의 Damage계수 = 총대미지
 
+        foreach (var skill in SkillDic.Values)
+        {
+            skill.IsCooldown = false;
+        }
 	}
 
 	public SkillData GetSkill(string skillName) => SkillDic.TryGetValue(skillName, out SkillData skill) ? skill : null;


### PR DESCRIPTION
## 요약

* 플레이어 AI 수정
* 플레이어 공격력 스탯 계산

---

## 작업 내용

* 플레이어 AI 대상탐색을 몬스터 수에서
1. 몬스터가 가장 많은 섹터
2. 몬스터들의 거리가 가장 가까운 섹터
를 기준으로 대상 선택

* 스탯의 레벨만으로 공격력 수치를 구하는 기능 추가

---

## 스크린샷 / 녹화
(필요하다면 GIF나 스크린샷을 첨부해 주세요)

---

## 테스트 방법
(직접 테스트해보는 방법을 단계별로 적어주세요)
1. 
2. 

---

## 해야 할 일 / 수정 사항

플레이어 AI 기본 공격과 연결
플레이어 스탯 계산 나머지 추가 (방어력, 체력, 이동속도 등)

---

## 체크리스트

- [x] 코드가 정상적으로 빌드/실행된다
- [x] 기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다
