### PR TITLE
Feat: 일반공격 로직 변경

### DIFF
--- a/Assets/CYH/CYH_Scenes/CYH_GameScene.unity
+++ b/Assets/CYH/CYH_Scenes/CYH_GameScene.unity
@@ -147,7 +147,7 @@ Transform:
   m_GameObject: {fileID: 790540494}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.54, y: -0.23, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1643,9 +1643,9 @@ MonoBehaviour:
   playerController: {fileID: 8834188468784387696}
   rayPos: {fileID: 790540495}
   attackRange: 2
-  isRayActive: 0
+  isActive: 0
   slashTime: 0
-  rotateSpeed: 72.9
+  rotateSpeed: 100
   isRotating: 0
 --- !u!20 &8994819570074998775
 Camera:

--- a/Assets/CYH/CYH_Scenes/CYH_GameScene.unity
+++ b/Assets/CYH/CYH_Scenes/CYH_GameScene.unity
@@ -122,6 +122,37 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &790540494
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 790540495}
+  m_Layer: 0
+  m_Name: RayPos
+  m_TagString: Untagged
+  m_Icon: {fileID: 4162164826716764455, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &790540495
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 790540494}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.54, y: -0.23, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7613547319140957043}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &887203758
 GameObject:
   m_ObjectHideFlags: 0
@@ -491,7 +522,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!212 &1147578126
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -607,7 +638,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c238eadf819680f4d84412605ca3eb66, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _data: {fileID: 0}
+  data: {fileID: 0}
   playerController: {fileID: 8834188468784387696}
 --- !u!70 &1147578131
 CapsuleCollider2D:
@@ -656,7 +687,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7308b36ed7b9d53409e6aa57c1e185cd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _data: {fileID: 0}
+  data: {fileID: 0}
   animator: {fileID: 8834188468784387697}
 --- !u!1 &1289211516
 GameObject:
@@ -1367,6 +1398,7 @@ GameObject:
   - component: {fileID: 8834188468784387696}
   - component: {fileID: 8834188468784387698}
   - component: {fileID: 8834188468784387699}
+  - component: {fileID: 8834188468784387700}
   m_Layer: 0
   m_Name: PlayerA
   m_TagString: Untagged
@@ -1472,6 +1504,7 @@ Transform:
   - {fileID: 891028608}
   - {fileID: 1872327061}
   - {fileID: 1399980450}
+  - {fileID: 790540495}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &8834188468784387695
@@ -1594,6 +1627,26 @@ MonoBehaviour:
   objSize: 5
   circleR: 1.5
   objSpeed: 140
+--- !u!114 &8834188468784387700
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2874512801222223151}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72294b7a72d95eb418353587f303cf96, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  data: {fileID: 0}
+  playerController: {fileID: 8834188468784387696}
+  rayPos: {fileID: 790540495}
+  attackRange: 2
+  isRayActive: 0
+  slashTime: 0
+  rotateSpeed: 72.9
+  isRotating: 0
 --- !u!20 &8994819570074998775
 Camera:
   m_ObjectHideFlags: 0

--- a/Assets/CYH/CYH_Scripts/Skill/SkillLogic_0.cs
+++ b/Assets/CYH/CYH_Scripts/Skill/SkillLogic_0.cs
@@ -1,16 +1,105 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
+using System.Collections;
 
-/// <summary>
-/// 스킬 0번 로직 구현 클래스입니다.
-/// </summary>
-public class SkillLogic_0 : SkillLogic
+public class SkillLogic_0 : MonoBehaviour
 {
-    [SerializeField] ActiveSkillData _data;
+    [SerializeField] private ActiveSkillData data;
+    [SerializeField] private PlayerControllerTypeA_Copy playerController;
 
-    public override void UseSkill()
+    [SerializeField] Transform rayPos;
+    [SerializeField] float attackRange = 1f;
+    [SerializeField] private bool isRayActive = false;
+
+    [SerializeField] float slashTime;
+    private int slashCount = 0;
+
+    [SerializeField][Range(1f, 100f)] float rotateSpeed = 50f;
+    [SerializeField] private bool isRotating = false;
+    private float angle = 0f;
+
+    private void EnableRaycast() => isRayActive = true;
+    private void DisableRaycast() => isRayActive = false;
+
+    private void Start()
     {
-        
+        playerController.facingDir = -1;
+    }
+
+    private void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Alpha5))
+        {
+            UseSkill();
+        }
+    }
+
+    public void UseSkill()
+    {
+        rayPos.localRotation = Quaternion.identity;
+        StartCoroutine(SkillRoutine());
+    }
+
+    private IEnumerator SkillRoutine()
+    {
+        EnableRaycast();
+        StartRotation();
+        slashCount = 1;
+        Debug.Log("스킬사용 1타");
+
+        // isRotating -> false 될 때까지 매 프레임 RotatePos(), DetectMonster() 실행
+        while (isRotating)
+        {
+            RotatePos();
+            DetectMonster();
+            yield return null;
+        }
+    }
+
+    private void DetectMonster()
+    {
+        if (!isRayActive)
+            return;
+
+        RaycastHit2D hit = Physics2D.Raycast(rayPos.position, rayPos.up, attackRange);
+        Debug.DrawRay(rayPos.position, rayPos.up * attackRange, Color.red);
+
+        if (hit.collider != null && hit.collider.CompareTag("Monster"))
+        {
+            Debug.Log("몬스터 감지");
+        }
+    }
+
+    private void StartRotation()
+    {
+        if (isRotating) return;
+        isRotating = true;
+        angle = 0f;
+    }
+
+    private void RotatePos()
+    {
+        if (!isRotating)
+            return;
+
+        float rotationAngle = Time.deltaTime * rotateSpeed*10;
+
+        if (angle + rotationAngle >= 180f)
+        {
+            float remain = 180f - angle;
+            rayPos.transform.Rotate(0, 0, remain, Space.Self);
+            isRotating = false;
+            OnRotationComplete();
+        }
+        else
+        {
+            rayPos.transform.Rotate(0, 0, rotationAngle, Space.Self);
+            angle += rotationAngle;
+        }
+    }
+
+    private void OnRotationComplete()
+    {
+        Debug.Log("180 회전 완료");
+        DisableRaycast(); 
     }
 }


### PR DESCRIPTION
## 요약
기존 로직: Weapon 오브젝트 애니메이션+Collider로 작동하던 로직
현재 로직: `rayPos`를 기준으로 Z축 180° 회전하며 몬스터 태그를 감지

---

## 작업 내용
- 1~2타 루프:  
  - 1타: 기본 방향에서 Z축 0→180° 회전  
  - 2타: Y축 180° 뒤집기 후 Z축 0→180° 회전  

---

## 스크린샷 / 녹화
![RaySkill](https://github.com/user-attachments/assets/8eed41f9-2f4e-4d35-a6ed-32d593e42743)

---

## 테스트 방법
- 키보드 숫자키 `5` 입력 -> 일반스킬 발동

---

## 해야 할 일 / 수정 사항
- 일반공격 로직을 Raycast → 히트박스 On/Off 방식으로 전환

---

## 체크리스트

- [x] 코드가 정상적으로 빌드/실행된다
- [x] 기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다
