### PR TITLE
Feat: 씬 매니저 기능 구현 (완)

### DIFF
--- a/Assets/CYH/CYH_Scripts/Scene/NextSceneButton.cs
+++ b/Assets/CYH/CYH_Scripts/Scene/NextSceneButton.cs
@@ -1,18 +1,10 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class NextSceneButton : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
+    // 버튼의 OnClick()에 연결
+    public void OnNextButtonClicked()
     {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
+        SceneChangeManager.Instance.LoadNextScene();
     }
 }

--- a/Assets/CYH/CYH_Scripts/Scene/SceneChangeManager.cs
+++ b/Assets/CYH/CYH_Scripts/Scene/SceneChangeManager.cs
@@ -13,8 +13,8 @@ public class SceneChangeManager : Singleton<SceneChangeManager>
     private float _minLoadingTime;                          // 최소 로드 시간
     private string _targetSceneName;                        // 로드할 씬
 
-    [SerializeField] private int _currentSceneIndex = 0;    // 현재 씬 번호                     
-    [SerializeField] private List<string> _stageInfo;       // 스테이지 리스트
+    public int _currentSceneIndex = 0;                      // 현재 씬 번호                     
+    public List<string> _stageInfo;                         // 스테이지 리스트
     private Dictionary<string, string> _gameSceneDict;      // 스테이지 정보 딕셔너리
 
 
@@ -22,8 +22,8 @@ public class SceneChangeManager : Singleton<SceneChangeManager>
     {
         base.Awake();
 
-        _stageInfo = LoadCsvToList("Csvs/StageInfo");
         _gameSceneDict = LoadCsvToDictionary("Csvs/GameScenes");
+        _stageInfo = LoadCsvToList("Csvs/StageInfo");
     }
 
     private void Start()
@@ -32,25 +32,8 @@ public class SceneChangeManager : Singleton<SceneChangeManager>
         LoadSceneAsync(_gameSceneDict[_stageInfo[0]]);
     }
 
-    void Update()
-    {
-        // 테스트
-
-        // 일반씬 -> 로딩씬 -> 목표씬
-        if (Input.GetKeyDown(KeyCode.Alpha0))
-            SceneChangeManager.Instance.LoadSceneWithLoading("LoadingScene", "BattleScene");
-
-        // 일반씬 -> 로딩씬 -> 목표씬 (최소 로드시간 보장)
-        if (Input.GetKeyDown(KeyCode.Alpha1))
-            SceneChangeManager.Instance.LoadSceneWithLoading("LoadingScene", "BattleScene", 5f);
-
-        // 씬 -> 씬
-        if (Input.GetKeyDown(KeyCode.Alpha3))
-            SceneChangeManager.Instance.LoadNextScene();
-    }
-
     /// <summary>
-    /// 현재 씬의 다음 씬 로드
+    /// 현재 씬의 다음 씬 로드 (SceneChangeManager.Instance.LoadNextScene())
     /// </summary>
     public void LoadNextScene()
     {
@@ -72,38 +55,14 @@ public class SceneChangeManager : Singleton<SceneChangeManager>
     }
 
     /// <summary>
-    /// 현재 씬의 다음 씬 로드 (씬 이름)
+    /// 다른 씬 로드 (스테이지 정보 ex.Stage1-1_Start)
     /// </summary>
-    public void LoadNextScene(string sceneName)
+    public void LoadNextScene(string stageInfo)
     {
-        LoadSceneAsync(sceneName);
-    }
-
-    /// <summary>
-    /// DialogParser DialogName에 파일 이름 넣기
-    /// </summary>
-    public void LoadFileName()
-    {
-        // 현재 씬이 대화씬인지 체크
-        if (SceneManager.GetActiveScene().name != "DialogScene")
-            return;
-
-        // 딕셔너리의 key -> 리스트로 변환
-
-        // DialogName에 들어갈 파일 이름
-        string dialogFileName = _stageInfo[_currentSceneIndex];
-
-        // 씬 내 DialogParser 컴포넌트 찾아서 세팅
-        var parser = FindObjectOfType<DialogParser>();
-        if (parser != null)
-        {
-            //parser.DialogName = dialogFileName;
-            Debug.Log($"DialogName 변경: {dialogFileName}");
-        }
-        else
-        {
-            Debug.LogWarning("현재 씬에 DialogParser 없음");
-        }
+        // stageInfo 씬 로드
+        LoadSceneAsync(_gameSceneDict[stageInfo]);
+        // 현재 씬 번호 -> 이동할 씬 번호로 변경                     
+        _currentSceneIndex = _stageInfo.IndexOf(stageInfo);
     }
 
     /// <summary>
@@ -150,9 +109,9 @@ public class SceneChangeManager : Singleton<SceneChangeManager>
     /// </summary>
     private IEnumerator LoadTwoSceneCoroutine(string loadingSceneName)
     {
-        // 1) 로딩씬 바로 로드
+        // 로딩씬 바로 로드
         yield return StartCoroutine(LoadSceneCoroutine(loadingSceneName));
-        // 2) 목표씬 바로 로드
+        // 목표씬 바로 로드
         yield return StartCoroutine(LoadSceneCoroutine(_targetSceneName));
     }
 
@@ -161,10 +120,9 @@ public class SceneChangeManager : Singleton<SceneChangeManager>
     /// </summary>
     private IEnumerator LoadTwoSceneCoroutineWithMinTime()
     {
-        // 1) 로딩씬 바로 로드
+        // 로딩씬 바로 로드
         yield return StartCoroutine(LoadSceneCoroutine("LoadingScene"));
-
-        // 2) 목표씬은 최소 로드시간 보장 후 로드
+        // 목표씬은 최소 로드시간 보장 후 로드
         yield return StartCoroutine(LoadingLoadSceneCoroutine(_targetSceneName, _minLoadingTime));
     }
 
@@ -190,9 +148,11 @@ public class SceneChangeManager : Singleton<SceneChangeManager>
             yield return null;
         }
 
+        //TODO: DialogScene인 경우 Player 초기화 스킵 처리
+
         // 로딩에 걸린 시간
         float elapsed = Time.time - _loadStartTime;
-        Debug.Log($"[{sceneName}] 로딩 완료: {elapsed:F1}초 소요");
+        Debug.Log($"[{_stageInfo[_currentSceneIndex]} / {sceneName}] 로딩 완료: {elapsed:F1}초 소요");
     }
 
     /// <summary>
@@ -206,7 +166,7 @@ public class SceneChangeManager : Singleton<SceneChangeManager>
         // 씬 로딩 완료되었을 때 대기
         _asyncLoad.allowSceneActivation = false;
 
-        // 로딩 진행도가 90% 이상 || 경과시간이 최소보장시간 이상일 때까지 대기
+        // 로딩 진행도가 90% 미만 || 경과시간이 최소보장시간 미만일 때 대기
         while (_asyncLoad.progress < 0.9f || Time.time - _loadStartTime < minTime)
         {
             float loadProgress = Mathf.Clamp01(_asyncLoad.progress / 0.9f);
@@ -216,10 +176,12 @@ public class SceneChangeManager : Singleton<SceneChangeManager>
             yield return null;
         }
 
+        //TODO: DialogScene인 경우 Player 초기화 스킵 처리
+
         _asyncLoad.allowSceneActivation = true;
         while (!_asyncLoad.isDone) yield return null;
 
-        Debug.Log($"[{sceneName}] 로딩 완료(최소 {minTime:F1}초 보장) 총 소요 시간: {(Time.time - _loadStartTime):F1}초");
+        Debug.Log($"[{_stageInfo[_currentSceneIndex]} / {sceneName}] 로딩 완료(최소 {minTime:F1}초 보장) 총 소요 시간: {(Time.time - _loadStartTime):F1}초");
     }
     #endregion
 

--- a/Assets/LYH/Scripts/DialogParser.cs
+++ b/Assets/LYH/Scripts/DialogParser.cs
@@ -71,7 +71,9 @@ public class DialogParser : MonoBehaviour
 
     void Start()
     {
-        // dialogName = 입력값
+        // dialogName = 입력값 (추가완료)
+        var sceneManager = SceneChangeManager.Instance;
+        dialogName = sceneManager._stageInfo[sceneManager._currentSceneIndex];
 
         for (int i = 0; i < dialogDatas.Length; i++)
         {

--- a/Assets/Resources/Csvs/GameScenes.csv
+++ b/Assets/Resources/Csvs/GameScenes.csv
@@ -22,7 +22,6 @@ Stage2-3_Battle,Stage2-3_Battle
 Stage2-3_Last,DialogScene
 Stage3-1_Start,DialogScene
 Stage3-1_Battle,Stage3-1_Battle
-Stage3-1_Middle,DialogScene
 Stage3-1_Last,DialogScene
 Stage3-2_Start,DialogScene
 Stage3-2_Battle,Stage3-2_Battle

--- a/Assets/Resources/Csvs/GameScenes.csv.meta
+++ b/Assets/Resources/Csvs/GameScenes.csv.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f51caf26cf9263948bdaf36e785acbfd
+guid: ea039a10b42b1c342991323b8653d7e8
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Resources/Csvs/StageInfo.csv
+++ b/Assets/Resources/Csvs/StageInfo.csv
@@ -22,7 +22,6 @@ Stage2-3_Battle
 Stage2-3_Last
 Stage3-1_Start
 Stage3-1_Battle
-Stage3-1_Middle
 Stage3-1_Last
 Stage3-2_Start
 Stage3-2_Battle

--- a/Assets/Resources/Csvs/StageInfo.csv.meta
+++ b/Assets/Resources/Csvs/StageInfo.csv.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2733766a12b5171469b3763b53e23612
+guid: 02becd1333aae25468d5f9045f3a25cb
 TextScriptImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
## 요약

씬 매니저 기능 구현

---

## 작업 내용
- 씬 전환 기능 로직 수정
- DialogScene에 현재 스테이지 정보 전달 기능 추가
- DialogScene인 경우 Player 초기화 스킵 처리 TODO 표시
- 씬 매니저에서 사용하는 csv 파일 변경 

---

## 스크린샷 / 녹화
![화면 캡처 2025-07-04 233401](https://github.com/user-attachments/assets/cc3c7b1e-6b50-45a7-a6a1-a11739e9905e)

---

## 테스트 방법
1. 대사 출력 완료 / 돌파미션 클리어 / (온정) 재화 첫 획득 시 -> LoadNextScene()  /  LoadNextScene(string stageInfo) 호출
2. 스킵하기 버튼 -> 버튼에 컴포넌트로 NextSceneButton.cs 추가 - NextSceneButton - OnNextButtonClicked() 메서드 연결


---

## 해야 할 일 / 수정 사항

---

## 체크리스트

- [x] 코드가 정상적으로 빌드/실행된다
- [x] 기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다
