### PR TITLE
[Fix] 업적 팝업창 보상 버튼 수정 및 미션 쿨타임 시간 수정

### DIFF
--- a/Assets/LHJ/LHJ_Scripts/LHJ_UI/AchievementPopUp.cs
+++ b/Assets/LHJ/LHJ_Scripts/LHJ_UI/AchievementPopUp.cs
@@ -48,7 +48,8 @@ public class AchievementPopUp : BaseUI
         // 업적 이름과 설명 UI 표시
         group.nameText.text = info.Name;
         group.descriptionText.text = info.Description;
-        group.rewardButton.gameObject.SetActive(true);
+        bool isAchieved = AchievementManager.Instance.IsAchieved(info.Id);  
+        group.rewardButton.gameObject.SetActive(isAchieved); // 업적 클리어시 버튼 활성화
 
         // 보상 버튼 클릭시 초기화 후 재등록
         group.rewardButton.onClick.RemoveAllListeners();

--- a/Assets/LHJ/LHJ_Scripts/Quest/MissionManager.cs
+++ b/Assets/LHJ/LHJ_Scripts/Quest/MissionManager.cs
@@ -81,7 +81,7 @@ public class MissionManager : Singleton<MissionManager>
     IEnumerator CooldownRoutine()
     {
         IsCooldownActive = true;    
-        CooldownSeconds = 6000f;     // 쿨타임 시간 설정
+        CooldownSeconds = 600f;     // 쿨타임 시간 설정
 
         while (CooldownSeconds > 0)
         {


### PR DESCRIPTION
업적 팝업창이 상시로 안나오고 해당 업적이 깨졌을때 보상 버튼이 나오도록 수정, 미션 시간 6000초 오타로 600초로 수정

## 요약
(이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요)

---  업적 팝업창 보상버튼 수정

## 작업 내용
(이 PR에서 어떤 작업이 있었는지 작성해주세요)
- 작업 1 업적 팝업창에서 보상버튼이 업적이 깨진 상태일때만 버튼이 나오도록 수정
- 작업 2 미션 실패시 쿨타임 시간이 6000초 오타로 600으로 수정

---

## 스크린샷 / 녹화
(필요하다면 GIF나 스크린샷을 첨부해 주세요)

--- 
<img width="665" alt="image" src="https://github.com/user-attachments/assets/e243c553-5c5e-4529-bb62-6607cada02a5" />


## 테스트 방법
(직접 테스트해보는 방법을 단계별로 적어주세요)
1. 
2. 

---

## 해야 할 일 / 수정 사항
(아직 남아 있는 문제, 추가로 개선할 부분이나 향후 수정이 필요한 내용을 적어주세요)

---

## 체크리스트

- [ ] 코드가 정상적으로 빌드/실행된다
- [ ] 기능이 정상 동작한다
- [ ] 심각한 버그나 예상치 못한 문제는 없다
