### PR TITLE
Fix : 스킬 6 이펙트 위치 및 사이즈 조정

### DIFF
--- a/Assets/CYH/CYH_Prefabs/Skill_6.prefab
+++ b/Assets/CYH/CYH_Prefabs/Skill_6.prefab
@@ -80,7 +80,7 @@ MonoBehaviour:
   _monsterLayer:
     serializedVersion: 2
     m_Bits: 512
-  _effectOffset: {x: 0, y: 3}
+  _effectOffset: {x: 2.8, y: 4.5}
   _damageInterval: 0.1
   _damageCount: 5
   _videoPrefab: {fileID: 2081190918094020834, guid: c216516ebe189034e9a5d48ecb683dd7, type: 3}

--- a/Assets/CYH/CYH_Prefabs/Skill_6_Effect.prefab
+++ b/Assets/CYH/CYH_Prefabs/Skill_6_Effect.prefab
@@ -28,8 +28,8 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
## 요약
스킬 6 이펙트 위치 및 사이즈 조정

---

## 작업 내용
- 스킬 6 이펙트 위치 및 사이즈 조정

---

## 스크린샷 / 녹화
![스크린샷 2025-07-07 041105](https://github.com/user-attachments/assets/21433c7b-55fd-415b-ba9f-17b8f7e71988)
![image](https://github.com/user-attachments/assets/bbdc1d9c-0fe1-406c-b4db-7da87c4be3c2)
![image](https://github.com/user-attachments/assets/c7502cfe-7017-474c-a562-4453e3aca06a)

---

## 테스트 방법
1. 전투 씬에서 스킬 6 사용시 확인 가능합니다.

---

## 해야 할 일 / 수정 사항
- 이펙트 크기에 맞게 히트박스 조정을 해야합니다

---

## 체크리스트

- [x] 코드가 정상적으로 빌드/실행된다
- [x] 기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다
