### PR TITLE
Fix: 플레이어 스킬_6 이펙트 생성 위치 수정

### DIFF
--- a/Assets/CYH/CYH_Scripts/Skill/SkillLogic_6.cs
+++ b/Assets/CYH/CYH_Scripts/Skill/SkillLogic_6.cs
@@ -183,6 +183,12 @@ public class SkillLogic_6 : SkillLogic, ISkill
         effectScale.x *= -1 * GetPlayerScaleX();
         effect.transform.localScale = effectScale;
         
+        // 플레이어가 왼쪽을 바라볼 때 이펙트 위치 x값 조정
+        if (effectScale.x > 0)
+        {
+            effect.transform.position = new Vector3(-1 * (_effectOffset.x), _effectOffset.y, 0);
+        }
+
         // 3초 뒤 삭제
         Destroy(effect, 3f);
     }


### PR DESCRIPTION
## 요약
플레이어 스킬_6 이펙트 생성 위치 수정

---

## 작업 내용

- 플레이어가 왼쪽을 바라볼 때 이펙트 생성 위치가 이펙트 offset.x 만큼 이동하던 문제 수정

---

## 스크린샷 / 녹화
- 오른쪽
![Skill_6_right](https://github.com/user-attachments/assets/7ced4849-a63c-4566-971f-a0475c2aa203)


- 왼쪽
![Skill_6_left](https://github.com/user-attachments/assets/d9dd7c34-dd63-4f86-ad33-57d4ef9a9d53)

---

## 테스트 방법

---

## 해야 할 일 / 수정 사항

---

## 체크리스트

- [x] 코드가 정상적으로 빌드/실행된다
- [x] 기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다
