### PR TITLE
Fix: 스킬 애니메이션 재생 후 이동 로직 보장 기능 추가

### DIFF
--- a/Assets/CYH/CYH_Animation/AnimationClips/Skill_3.anim
+++ b/Assets/CYH/CYH_Animation/AnimationClips/Skill_3.anim
@@ -104,3 +104,10 @@ AnimationClip:
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
+  - time: 3
+    functionName: Skill3_OnAttackEnd
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/CYH/CYH_Animation/AnimationClips/Skill_6.anim
+++ b/Assets/CYH/CYH_Animation/AnimationClips/Skill_6.anim
@@ -86,3 +86,10 @@ AnimationClip:
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
+  - time: 3
+    functionName: Skill6_OnAttackEnd
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/CYH/CYH_Animation/AnimatorController/PlayerAnimationController.controller
+++ b/Assets/CYH/CYH_Animation/AnimatorController/PlayerAnimationController.controller
@@ -145,7 +145,7 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0.25
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
+  m_ExitTime: 1.2
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0

--- a/Assets/CYH/CYH_Scripts/Skill/SkillLogic_1.cs
+++ b/Assets/CYH/CYH_Scripts/Skill/SkillLogic_1.cs
@@ -29,14 +29,6 @@ public class SkillLogic_1 : SkillLogic, ISkill
         _effectSpawnPos = new Vector3(0, 12.22765f, 0);
     }
 
-    private void Update()
-    {
-        if(Input.GetKeyDown(KeyCode.Alpha1))
-        {
-            UseSkill(transform);
-        }
-    }
-
     public bool UseSkill(Transform attacker)
     {
         Debug.Log("스킬 1 UseSkill");
@@ -104,6 +96,14 @@ public class SkillLogic_1 : SkillLogic, ISkill
 
         // 플레이어 움직임 비활성화
         PlayerController.Instance.Stop();
+
+        // 1초 뒤 플레이어 움직임 활성화
+        Invoke("PlayerMove", 1f);
+    }
+
+    private void PlayerMove()
+    {
+        PlayerController.Instance.Move();
     }
 
     public void CreateEffect()

--- a/Assets/CYH/CYH_Scripts/Skill/SkillLogic_2.cs
+++ b/Assets/CYH/CYH_Scripts/Skill/SkillLogic_2.cs
@@ -109,11 +109,6 @@ public class SkillLogic_2 : SkillLogic, ISkill
         OnAttackEnd();
     }
 
-    public void AnimationPlay()
-    {
-        PlayerController.Instance.SetTrigger("UseSkill_2");
-    }
-
     public void OnAttackStart()
     {
         _isSkillUsed = true;
@@ -125,6 +120,19 @@ public class SkillLogic_2 : SkillLogic, ISkill
     public void OnAttackEnd()
     {
         _isSkillUsed = false;
+        PlayerController.Instance.Move();
+    }
+
+    public void AnimationPlay()
+    {
+        PlayerController.Instance.SetTrigger("UseSkill_2");
+
+        // 10프레임 후 플레이어 이동 활성화
+        Invoke("PlayerMove", 0.17f);
+    }
+
+    private void PlayerMove()
+    {
         PlayerController.Instance.Move();
     }
 

--- a/Assets/CYH/CYH_Scripts/Skill/SkillLogic_3.cs
+++ b/Assets/CYH/CYH_Scripts/Skill/SkillLogic_3.cs
@@ -107,8 +107,6 @@ public class SkillLogic_3 : SkillLogic, ISkill
     {
         if (_highestMonster != null)
             PlayerController.Instance.StartCoroutine(DamageCoroutine(_highestMonster));
-
-        OnAttackEnd();
     }
 
     public void OnAttackStart()

--- a/Assets/CYH/CYH_Scripts/Skill/SkillLogic_3.cs
+++ b/Assets/CYH/CYH_Scripts/Skill/SkillLogic_3.cs
@@ -31,14 +31,6 @@ public class SkillLogic_3 : SkillLogic, ISkill
         SlotIndex = -1;
     }
 
-    private void Update()
-    {
-        if(Input.GetKeyDown(KeyCode.Alpha3))
-        {
-            UseSkill(transform);
-        }
-    }
-
     public bool UseSkill(Transform attacker)
     {
         // 쿨타임이면 return
@@ -109,6 +101,15 @@ public class SkillLogic_3 : SkillLogic, ISkill
             PlayerController.Instance.StartCoroutine(DamageCoroutine(_highestMonster));
     }
 
+    public void AnimationPlay()
+    {
+        //_animator.SetTrigger("UseSkill_3");
+        PlayerController.Instance.SetTrigger("UseSkill_3");
+
+        // 3초 뒤 플레이어 이동 활성화
+        Invoke("PlayerMove", 3f);
+    }
+
     public void OnAttackStart()
     {
         _isSkillUsed = true;
@@ -122,10 +123,9 @@ public class SkillLogic_3 : SkillLogic, ISkill
         PlayerController.Instance.Move();
     }
 
-    public void AnimationPlay()
+    private void PlayerMove()
     {
-        //_animator.SetTrigger("UseSkill_3");
-        PlayerController.Instance.SetTrigger("UseSkill_3");
+        PlayerController.Instance.Move();
     }
 
     private void DetectMonster()

--- a/Assets/CYH/CYH_Scripts/Skill/SkillLogic_4.cs
+++ b/Assets/CYH/CYH_Scripts/Skill/SkillLogic_4.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UIElements.Experimental;
 
 public class SkillLogic_4 : SkillLogic, ISkill
 {
@@ -65,6 +66,8 @@ public class SkillLogic_4 : SkillLogic, ISkill
         }
 
         // 쿨타임 체크 시작
+        IsCooldown = true;
+
         PlayerController.Instance.StartCoroutine(CooldownCoroutine());
 
         OnAttackStart();
@@ -81,6 +84,7 @@ public class SkillLogic_4 : SkillLogic, ISkill
         // 쿨타임이면 return
         if (IsCooldown || !PlayerController.Instance.MoveCheck()) return false;
 
+
         // 쿨타임 전에 몬스터가 있으면 실행 없으면 return
         // 스킬 발동 전 몬스터 목록 초기화
         _hitMonsters.Clear();
@@ -93,6 +97,8 @@ public class SkillLogic_4 : SkillLogic, ISkill
         }
 
         // 쿨타임 체크 시작
+        IsCooldown = true;
+        
         PlayerController.Instance.StartCoroutine(CooldownCoroutine());
 
         OnAttackStart();
@@ -116,6 +122,15 @@ public class SkillLogic_4 : SkillLogic, ISkill
         OnAttackEnd();
     }
 
+    public void AnimationPlay()
+    {
+        //_animator.SetTrigger("UseSkill_4");
+        PlayerController.Instance.SetTrigger("UseSkill_4");
+        
+        // 1초 뒤 플레이어 움직임 활성화
+        Invoke("PlayerMove", 1f);
+    }
+
     public void OnAttackStart()
     {
         _isSkillUsed = true;
@@ -132,10 +147,9 @@ public class SkillLogic_4 : SkillLogic, ISkill
         Debug.Log($"플레이어 정지 해제 : {PlayerController.Instance.MoveCheck()}");
     }
 
-    public void AnimationPlay()
+    private void PlayerMove()
     {
-        //_animator.SetTrigger("UseSkill_4");
-        PlayerController.Instance.SetTrigger("UseSkill_4");
+        PlayerController.Instance.Move();
     }
 
     // 범위 안의 모든 몬스터 탐색

--- a/Assets/CYH/CYH_Scripts/Skill/SkillLogic_5.cs
+++ b/Assets/CYH/CYH_Scripts/Skill/SkillLogic_5.cs
@@ -94,6 +94,14 @@ public class SkillLogic_5 : SkillLogic, ISkill
     {
         //_animator.SetTrigger("UseSkill_5");
         PlayerController.Instance.SetTrigger("UseSkill_5");
+
+        // 1초 뒤 플레이어 움직임 활성화
+        Invoke("PlayerMove", 1f);
+    }
+
+    private void PlayerMove()
+    {
+        PlayerController.Instance.Move();
     }
 
     // Field 생성

--- a/Assets/CYH/CYH_Scripts/Skill/SkillLogic_6.cs
+++ b/Assets/CYH/CYH_Scripts/Skill/SkillLogic_6.cs
@@ -89,7 +89,6 @@ public class SkillLogic_6 : SkillLogic, ISkill
     public void SkillRoutine()
     {
         PlayerController.Instance.StartCoroutine(DamageRoutine());
-        OnAttackEnd();
     }
 
     public void OnAttackStart()

--- a/Assets/CYH/CYH_Scripts/Skill/SkillLogic_6.cs
+++ b/Assets/CYH/CYH_Scripts/Skill/SkillLogic_6.cs
@@ -110,6 +110,14 @@ public class SkillLogic_6 : SkillLogic, ISkill
     {
         //_animator.SetTrigger("UseSkill_6");
         PlayerController.Instance.SetTrigger("UseSkill_6");
+
+        // 3초 뒤 플레이어 움직임 활성화
+        Invoke("PlayerMove", 3f);
+    }
+
+    private void PlayerMove()
+    {
+        PlayerController.Instance.Move();
     }
 
     // 궁극기 비디오 생성

--- a/Assets/SJH/SJH_Scripts/PlayerController.cs
+++ b/Assets/SJH/SJH_Scripts/PlayerController.cs
@@ -590,6 +590,7 @@ public class PlayerController : MonoBehaviour
 
     // SkillLogic_3 애니메이션 이벤트 함수
     public void Skill3_SkillRoutine() => (SkillController.SkillList[3] as SkillLogic_3)?.SkillRoutine();
+    public void Skill3_OnAttackEnd() => (SkillController.SkillList[3] as SkillLogic_3)?.OnAttackEnd();
 
     // SkillLogic_4 애니메이션 이벤트 함수
     public void Skill4_SkillRoutine() => (SkillController.SkillList[4] as SkillLogic_4)?.SkillRoutine();

--- a/Assets/SJH/SJH_Scripts/PlayerController.cs
+++ b/Assets/SJH/SJH_Scripts/PlayerController.cs
@@ -600,6 +600,7 @@ public class PlayerController : MonoBehaviour
 
     // SkillLogic_6 애니메이션 이벤트 함수
     public void Skill6_SkillRoutine() => (SkillController.SkillList[6] as SkillLogic_6)?.SkillRoutine();
+    public void Skill6_OnAttackEnd() => (SkillController.SkillList[6] as SkillLogic_6)?.OnAttackEnd();
 
     #endregion
 


### PR DESCRIPTION
## 요약
스킬 애니메이션 재생 후 이동 로직 보장 기능 추가 및 스킬_3, 4 움직임 활성화 타이밍 수정 

---

## 작업 내용

- 스킬_6 공격 적용 타이밍과 플레이어 움직임 활성화 타이밍 분리
- 스킬_3
변경 전: 공격이 적용되는 타이밍에 움직임 활성화
변경 후: 스킬 애니메이션이 완전히 끝난 후 움직임 활성화
- 스킬_1~6 애니메이션 재생 완료 후 이동 기능이 항상 활성화되도록 보장 로직 추가

---

## 스크린샷 / 녹화


---

## 테스트 방법

---

## 해야 할 일 / 수정 사항


---

## 체크리스트

- [x] 코드가 정상적으로 빌드/실행된다
- [x] 기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다
